### PR TITLE
Improve TTFB snippet

### DIFF
--- a/code/ttfb/ttfb.js
+++ b/code/ttfb/ttfb.js
@@ -1,3 +1,8 @@
+/**
+ * Time to First Byte (TTFB) is a measurement used as an indication of the responsiveness of a webserver or other network resource. 
+ * TTFB measures the duration from the user or client making an HTTP request to the first byte of the page being received by the client's browser.
+ */
+
 (() => {
 
   const formatTime = (time) => {

--- a/code/ttfb/ttfb.js
+++ b/code/ttfb/ttfb.js
@@ -1,8 +1,3 @@
-/**
- * Time to First Byte (TTFB) is a measurement used as an indication of the responsiveness of a webserver or other network resource. 
- * TTFB measures the duration from the user or client making an HTTP request to the first byte of the page being received by the client's browser.
- */
-
 (() => {
 
   const formatTime = (time) => {
@@ -15,23 +10,23 @@
 
     // timing start times are relative
     const activationStart = pageNav.activationStart || 0;
-    const workerStart = Math.max(pageNav.workerStart - activationStart, activationStart);
-    const dnsStart = Math.max(pageNav.domainLookupStart - activationStart, workerStart);
-    const tcpStart = Math.max(pageNav.connectStart - activationStart, dnsStart);
-    const sslStart = Math.max(pageNav.secureConnectionStart - activationStart, tcpStart);
-    const requestStart = Math.max(pageNav.requestStart - activationStart, sslStart);
-    const responseStart = Math.max(pageNav.responseStart - activationStart, requestStart);
+    const waitEnd = Math.max((pageNav.workerStart || pageNav.fetchStart) - activationStart, 0);
+    const dnsStart = Math.max(pageNav.domainLookupStart - activationStart, 0);
+    const tcpStart = Math.max(pageNav.connectStart - activationStart, 0);
+    const sslStart = Math.max(pageNav.secureConnectionStart - activationStart, 0);
+    const tcpEnd = Math.max(pageNav.connectEnd - activationStart, 0);
+    const responseStart = Math.max(pageNav.responseStart - activationStart, 0);
 
     // attribution based on https://www.w3.org/TR/navigation-timing-2/#processing-model
     // use associative array to log the results more readable
     let attributionArray = [];
-    attributionArray['Redirect Time'] = {'time in ms':formatTime(workerStart - activationStart)};
-    attributionArray['Worker and Cache Time'] = {'time in ms':formatTime(dnsStart - workerStart)};
-    attributionArray['DNS Time'] = {'time in ms':formatTime(tcpStart - dnsStart)};
-    attributionArray['TCP Time'] = {'time in ms':formatTime(sslStart - tcpStart)};
-    attributionArray['SSL Time'] = {'time in ms':formatTime(requestStart - sslStart)};
-    attributionArray['Request Time'] = {'time in ms':formatTime(responseStart - requestStart)};
-    attributionArray['Total TTFB'] = {'time in ms':formatTime(responseStart - activationStart)};
+    attributionArray['Redirect and Waiting duration'] = {'time in ms':formatTime(waitEnd)};
+    attributionArray['Worker and Cache duration'] = {'time in ms':formatTime(dnsStart - waitEnd)};
+    attributionArray['DNS duration'] = {'time in ms':formatTime(tcpStart - dnsStart)};
+    attributionArray['TCP duration'] = {'time in ms':formatTime(sslStart - tcpStart)};
+    attributionArray['SSL duration'] = {'time in ms':formatTime(tcpEnd - sslStart)};
+    attributionArray['Request duration'] = {'time in ms':formatTime(responseStart - tcpEnd)};
+    attributionArray['Total TTFB'] = {'time in ms':formatTime(responseStart)};
 
     // log the results
     console.log('%cTime to First Byte ('+formatTime(responseStart - activationStart)+'ms)', 'color: blue; font-weight: bold;');


### PR DESCRIPTION
Copying over improvements from https://github.com/nucliweb/webperf-snippets/pull/47

Makes the following  changes:
- Redirect time cannot be accurate measured so renames it to "Redirect and waiting duration".
- "Redirect and waiting duration" should be measured from `workerStart` OR `fetchStart` to handle non-SW pages.
- All times should be clamped to 0 after subtracting `activationStart` to accurately measure TTFB from activation for prerendered pages (i.e. from when user clicks rather than from when browser starts prerendering).
- This is often a gap from `connectEnd` to `requestStarts` which is currently being attributed to SSL time. Make the following changes:
  - Change `SSL duration` to measure from `secureConnectionStart ` to `connectEnd` to more accurately measure this.
  - Measure request from `connectEnd` rather than `requestStart` so the gap is included in request time instead.
  - This is necessary as service worker requests do not allow measurement of TCP or SSL time so they should be 0 so better to attribute to request time than SSL time.
- Changes all "times" to "durations" to make clear they are spans of time and not actual times.
